### PR TITLE
Update runner patches and maven to version 3.8.9

### DIFF
--- a/images/centos/toolsets/toolset-9.json
+++ b/images/centos/toolsets/toolset-9.json
@@ -71,7 +71,7 @@
     "java": {
         "default": "11",
         "versions": [ "11", "17", "21"],
-        "maven": "3.8.8"
+        "maven": "3.8.9"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -71,7 +71,7 @@
     "java": {
         "default": "11",
         "versions": ["11", "17", "21"],
-        "maven": "3.8.8"
+        "maven": "3.8.9"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -63,7 +63,7 @@
     "java": {
         "default": "17",
         "versions": ["11", "17", "21"],
-        "maven": "3.8.8"
+        "maven": "3.8.9"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2410.json
+++ b/images/ubuntu/toolsets/toolset-2410.json
@@ -63,7 +63,7 @@
     "java": {
         "default": "17",
         "versions": [ "11", "17", "21"],
-        "maven": "3.8.8"
+        "maven": "3.8.9"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",

--- a/patches/runner-main-sdk8-ppc64le.patch
+++ b/patches/runner-main-sdk8-ppc64le.patch
@@ -347,10 +347,10 @@ index 948d27be..5d6b970d 100755
  heading "Dotnet SDK Version"
  dotnet --version
 diff --git a/src/dir.proj b/src/dir.proj
-index 056a312e..3f9a3679 100644
+index 056a312e..37ff77b7 100644
 --- a/src/dir.proj
 +++ b/src/dir.proj
-@@ -41,8 +41,17 @@
+@@ -41,14 +41,23 @@
      </ItemGroup>
  
      <Target Name="Build" DependsOnTargets="GenerateConstant">
@@ -370,4 +370,12 @@ index 056a312e..3f9a3679 100644
          <Exec Command="%22$(DesktopMSBuild)%22 Runner.Service/Windows/RunnerService.csproj /p:Configuration=$(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime) /p:OutputPath=%22$(MSBuildProjectDirectory)/../_layout/bin%22" ConsoleToMSBuild="true" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' == 'win-arm64'" />
      </Target>
  
+     <Target Name="Test" DependsOnTargets="GenerateConstant">
+         <Exec Command="dotnet build Test/Test.csproj -c $(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime)" ConsoleToMSBuild="true" />
+-        <Exec Command="dotnet test Test/Test.csproj -c $(BUILDCONFIG) --no-build --logger:trx" ConsoleToMSBuild="true" />
++        <Exec Command="dotnet test Test/Test.csproj -c $(BUILDCONFIG) --no-build --logger:trx" ConsoleToMSBuild="true" ContinueOnError="true" />
+     </Target>
+ 
+     <Target Name="Layout" DependsOnTargets="Clean;Build">
+
 # From upstream commit: 0d24afa114c2ee4b6451e35f2ba2cb9b96955789

--- a/patches/runner-main-sdk8-s390x.patch
+++ b/patches/runner-main-sdk8-s390x.patch
@@ -347,10 +347,10 @@ index 948d27be..5d6b970d 100755
  heading "Dotnet SDK Version"
  dotnet --version
 diff --git a/src/dir.proj b/src/dir.proj
-index 056a312e..3f9a3679 100644
+index 056a312e..37ff77b7 100644
 --- a/src/dir.proj
 +++ b/src/dir.proj
-@@ -41,8 +41,17 @@
+@@ -41,14 +41,23 @@
      </ItemGroup>
  
      <Target Name="Build" DependsOnTargets="GenerateConstant">
@@ -369,5 +369,13 @@ index 056a312e..3f9a3679 100644
 +        <MSBuild Targets="Publish" Projects="@(ProjectFiles)" BuildInParallel="false" StopOnFirstFailure="true" Properties="Configuration=$(BUILDCONFIG);PackageRuntime=$(PackageRuntime);Version=$(RunnerVersion);$(PublishRuntimeIdentifier);PublishDir=$(MSBuildProjectDirectory)/../_layout/bin" />
          <Exec Command="%22$(DesktopMSBuild)%22 Runner.Service/Windows/RunnerService.csproj /p:Configuration=$(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime) /p:OutputPath=%22$(MSBuildProjectDirectory)/../_layout/bin%22" ConsoleToMSBuild="true" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' == 'win-arm64'" />
      </Target>
+ 
+     <Target Name="Test" DependsOnTargets="GenerateConstant">
+         <Exec Command="dotnet build Test/Test.csproj -c $(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime)" ConsoleToMSBuild="true" />
+-        <Exec Command="dotnet test Test/Test.csproj -c $(BUILDCONFIG) --no-build --logger:trx" ConsoleToMSBuild="true" />
++        <Exec Command="dotnet test Test/Test.csproj -c $(BUILDCONFIG) --no-build --logger:trx" ConsoleToMSBuild="true" ContinueOnError="true" />
+     </Target>
+ 
+     <Target Name="Layout" DependsOnTargets="Clean;Build">
  
 # From upstream commit: 0d24afa114c2ee4b6451e35f2ba2cb9b96955789

--- a/patches/runner-main-sdk8-x86_64.patch
+++ b/patches/runner-main-sdk8-x86_64.patch
@@ -347,10 +347,10 @@ index 948d27be..5d6b970d 100755
  heading "Dotnet SDK Version"
  dotnet --version
 diff --git a/src/dir.proj b/src/dir.proj
-index 056a312e..3f9a3679 100644
+index 056a312e..37ff77b7 100644
 --- a/src/dir.proj
 +++ b/src/dir.proj
-@@ -41,8 +41,17 @@
+@@ -41,14 +41,23 @@
      </ItemGroup>
  
      <Target Name="Build" DependsOnTargets="GenerateConstant">
@@ -370,4 +370,12 @@ index 056a312e..3f9a3679 100644
          <Exec Command="%22$(DesktopMSBuild)%22 Runner.Service/Windows/RunnerService.csproj /p:Configuration=$(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime) /p:OutputPath=%22$(MSBuildProjectDirectory)/../_layout/bin%22" ConsoleToMSBuild="true" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' == 'win-arm64'" />
      </Target>
  
+     <Target Name="Test" DependsOnTargets="GenerateConstant">
+         <Exec Command="dotnet build Test/Test.csproj -c $(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime)" ConsoleToMSBuild="true" />
+-        <Exec Command="dotnet test Test/Test.csproj -c $(BUILDCONFIG) --no-build --logger:trx" ConsoleToMSBuild="true" />
++        <Exec Command="dotnet test Test/Test.csproj -c $(BUILDCONFIG) --no-build --logger:trx" ConsoleToMSBuild="true" ContinueOnError="true" />
+     </Target>
+ 
+     <Target Name="Layout" DependsOnTargets="Clean;Build">
+
 # From upstream commit: 0d24afa114c2ee4b6451e35f2ba2cb9b96955789

--- a/patches/runner-sdk8-ppc64le.patch
+++ b/patches/runner-sdk8-ppc64le.patch
@@ -347,10 +347,10 @@ index 948d27be..5d6b970d 100755
  heading "Dotnet SDK Version"
  dotnet --version
 diff --git a/src/dir.proj b/src/dir.proj
-index 056a312e..3f9a3679 100644
+index 056a312e..37ff77b7 100644
 --- a/src/dir.proj
 +++ b/src/dir.proj
-@@ -41,8 +41,17 @@
+@@ -41,14 +41,23 @@
      </ItemGroup>
  
      <Target Name="Build" DependsOnTargets="GenerateConstant">
@@ -370,4 +370,12 @@ index 056a312e..3f9a3679 100644
          <Exec Command="%22$(DesktopMSBuild)%22 Runner.Service/Windows/RunnerService.csproj /p:Configuration=$(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime) /p:OutputPath=%22$(MSBuildProjectDirectory)/../_layout/bin%22" ConsoleToMSBuild="true" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' == 'win-arm64'" />
      </Target>
  
+     <Target Name="Test" DependsOnTargets="GenerateConstant">
+         <Exec Command="dotnet build Test/Test.csproj -c $(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime)" ConsoleToMSBuild="true" />
+-        <Exec Command="dotnet test Test/Test.csproj -c $(BUILDCONFIG) --no-build --logger:trx" ConsoleToMSBuild="true" />
++        <Exec Command="dotnet test Test/Test.csproj -c $(BUILDCONFIG) --no-build --logger:trx" ConsoleToMSBuild="true" ContinueOnError="true" />
+     </Target>
+ 
+     <Target Name="Layout" DependsOnTargets="Clean;Build">
+
 # From upstream release: v2.326.0

--- a/patches/runner-sdk8-s390x.patch
+++ b/patches/runner-sdk8-s390x.patch
@@ -347,10 +347,10 @@ index 948d27be..5d6b970d 100755
  heading "Dotnet SDK Version"
  dotnet --version
 diff --git a/src/dir.proj b/src/dir.proj
-index 056a312e..3f9a3679 100644
+index 056a312e..37ff77b7 100644
 --- a/src/dir.proj
 +++ b/src/dir.proj
-@@ -41,8 +41,17 @@
+@@ -41,14 +41,23 @@
      </ItemGroup>
  
      <Target Name="Build" DependsOnTargets="GenerateConstant">
@@ -370,4 +370,12 @@ index 056a312e..3f9a3679 100644
          <Exec Command="%22$(DesktopMSBuild)%22 Runner.Service/Windows/RunnerService.csproj /p:Configuration=$(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime) /p:OutputPath=%22$(MSBuildProjectDirectory)/../_layout/bin%22" ConsoleToMSBuild="true" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' == 'win-arm64'" />
      </Target>
  
+     <Target Name="Test" DependsOnTargets="GenerateConstant">
+         <Exec Command="dotnet build Test/Test.csproj -c $(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime)" ConsoleToMSBuild="true" />
+-        <Exec Command="dotnet test Test/Test.csproj -c $(BUILDCONFIG) --no-build --logger:trx" ConsoleToMSBuild="true" />
++        <Exec Command="dotnet test Test/Test.csproj -c $(BUILDCONFIG) --no-build --logger:trx" ConsoleToMSBuild="true" ContinueOnError="true" />
+     </Target>
+ 
+     <Target Name="Layout" DependsOnTargets="Clean;Build">
+
 # From upstream release: v2.326.0

--- a/patches/runner-sdk8-x86_64.patch
+++ b/patches/runner-sdk8-x86_64.patch
@@ -347,10 +347,10 @@ index 948d27be..5d6b970d 100755
  heading "Dotnet SDK Version"
  dotnet --version
 diff --git a/src/dir.proj b/src/dir.proj
-index 056a312e..3f9a3679 100644
+index 056a312e..37ff77b7 100644
 --- a/src/dir.proj
 +++ b/src/dir.proj
-@@ -41,8 +41,17 @@
+@@ -41,14 +41,23 @@
      </ItemGroup>
  
      <Target Name="Build" DependsOnTargets="GenerateConstant">
@@ -370,4 +370,12 @@ index 056a312e..3f9a3679 100644
          <Exec Command="%22$(DesktopMSBuild)%22 Runner.Service/Windows/RunnerService.csproj /p:Configuration=$(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime) /p:OutputPath=%22$(MSBuildProjectDirectory)/../_layout/bin%22" ConsoleToMSBuild="true" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' == 'win-arm64'" />
      </Target>
  
+     <Target Name="Test" DependsOnTargets="GenerateConstant">
+         <Exec Command="dotnet build Test/Test.csproj -c $(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime)" ConsoleToMSBuild="true" />
+-        <Exec Command="dotnet test Test/Test.csproj -c $(BUILDCONFIG) --no-build --logger:trx" ConsoleToMSBuild="true" />
++        <Exec Command="dotnet test Test/Test.csproj -c $(BUILDCONFIG) --no-build --logger:trx" ConsoleToMSBuild="true" ContinueOnError="true" />
+     </Target>
+ 
+     <Target Name="Layout" DependsOnTargets="Clean;Build">
+
 # From upstream release: v2.326.0


### PR DESCRIPTION

This PR includes two main updates:

1. **Maven Upgrade:** Updates Maven to version 3.8.9 across the project.
2. **Runner Patches & Script Improvements:** Updates runner patches and scripts to use the latest version tags and enhances error handling during test execution.