### PR TITLE
Update patches to include support for NODE24 in ppc64le and s390x architectures

### DIFF
--- a/patches/runner-main-sdk8-ppc64le.patch
+++ b/patches/runner-main-sdk8-ppc64le.patch
@@ -16,20 +16,22 @@ index 9c069b12..d26b0dc2 100644
    <!-- Set TRACE/DEBUG vars -->
    <PropertyGroup>
 diff --git a/src/Misc/externals.sh b/src/Misc/externals.sh
-index ca8f6c28..5d06f9be 100755
+index ca8f6c28..07d08a0e 100755
 --- a/src/Misc/externals.sh
 +++ b/src/Misc/externals.sh
-@@ -187,3 +187,11 @@ fi
+@@ -187,3 +187,13 @@ fi
  if [[ "$PACKAGERUNTIME" == "linux-arm" ]]; then
      acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-armv7l.tar.gz" node20 fix_nested_dir
  fi
 +
 +if [[ "$PACKAGERUNTIME" == "linux-ppc64le" ]]; then
 +    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-ppc64le.tar.gz" node20 fix_nested_dir
++    acquireExternalTool "$NODE_URL/v${NODE24_VERSION}/node-v${NODE24_VERSION}-linux-ppc64le.tar.gz" node24 fix_nested_dir
 +fi
 +
 +if [[ "$PACKAGERUNTIME" == "linux-s390x" ]]; then
 +    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-s390x.tar.gz" node20 fix_nested_dir
++    acquireExternalTool "$NODE_URL/v${NODE24_VERSION}/node-v${NODE24_VERSION}-linux-s390x.tar.gz" node24 fix_nested_dir
 +fi
 \ No newline at end of file
 diff --git a/src/Misc/layoutroot/config.sh b/src/Misc/layoutroot/config.sh

--- a/patches/runner-main-sdk8-s390x.patch
+++ b/patches/runner-main-sdk8-s390x.patch
@@ -16,20 +16,22 @@ index 9c069b12..d26b0dc2 100644
    <!-- Set TRACE/DEBUG vars -->
    <PropertyGroup>
 diff --git a/src/Misc/externals.sh b/src/Misc/externals.sh
-index ca8f6c28..5d06f9be 100755
+index ca8f6c28..07d08a0e 100755
 --- a/src/Misc/externals.sh
 +++ b/src/Misc/externals.sh
-@@ -187,3 +187,11 @@ fi
+@@ -187,3 +187,13 @@ fi
  if [[ "$PACKAGERUNTIME" == "linux-arm" ]]; then
      acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-armv7l.tar.gz" node20 fix_nested_dir
  fi
 +
 +if [[ "$PACKAGERUNTIME" == "linux-ppc64le" ]]; then
 +    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-ppc64le.tar.gz" node20 fix_nested_dir
++    acquireExternalTool "$NODE_URL/v${NODE24_VERSION}/node-v${NODE24_VERSION}-linux-ppc64le.tar.gz" node24 fix_nested_dir
 +fi
 +
 +if [[ "$PACKAGERUNTIME" == "linux-s390x" ]]; then
 +    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-s390x.tar.gz" node20 fix_nested_dir
++    acquireExternalTool "$NODE_URL/v${NODE24_VERSION}/node-v${NODE24_VERSION}-linux-s390x.tar.gz" node24 fix_nested_dir
 +fi
 \ No newline at end of file
 diff --git a/src/Misc/layoutroot/config.sh b/src/Misc/layoutroot/config.sh

--- a/patches/runner-main-sdk8-x86_64.patch
+++ b/patches/runner-main-sdk8-x86_64.patch
@@ -16,20 +16,22 @@ index 9c069b12..d26b0dc2 100644
    <!-- Set TRACE/DEBUG vars -->
    <PropertyGroup>
 diff --git a/src/Misc/externals.sh b/src/Misc/externals.sh
-index ca8f6c28..5d06f9be 100755
+index ca8f6c28..07d08a0e 100755
 --- a/src/Misc/externals.sh
 +++ b/src/Misc/externals.sh
-@@ -187,3 +187,11 @@ fi
+@@ -187,3 +187,13 @@ fi
  if [[ "$PACKAGERUNTIME" == "linux-arm" ]]; then
      acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-armv7l.tar.gz" node20 fix_nested_dir
  fi
 +
 +if [[ "$PACKAGERUNTIME" == "linux-ppc64le" ]]; then
 +    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-ppc64le.tar.gz" node20 fix_nested_dir
++    acquireExternalTool "$NODE_URL/v${NODE24_VERSION}/node-v${NODE24_VERSION}-linux-ppc64le.tar.gz" node24 fix_nested_dir
 +fi
 +
 +if [[ "$PACKAGERUNTIME" == "linux-s390x" ]]; then
 +    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-s390x.tar.gz" node20 fix_nested_dir
++    acquireExternalTool "$NODE_URL/v${NODE24_VERSION}/node-v${NODE24_VERSION}-linux-s390x.tar.gz" node24 fix_nested_dir
 +fi
 \ No newline at end of file
 diff --git a/src/Misc/layoutroot/config.sh b/src/Misc/layoutroot/config.sh

--- a/patches/runner-sdk8-ppc64le.patch
+++ b/patches/runner-sdk8-ppc64le.patch
@@ -16,20 +16,22 @@ index 9c069b12..d26b0dc2 100644
    <!-- Set TRACE/DEBUG vars -->
    <PropertyGroup>
 diff --git a/src/Misc/externals.sh b/src/Misc/externals.sh
-index ca8f6c28..5d06f9be 100755
+index ca8f6c28..07d08a0e 100755
 --- a/src/Misc/externals.sh
 +++ b/src/Misc/externals.sh
-@@ -187,3 +187,11 @@ fi
+@@ -187,3 +187,13 @@ fi
  if [[ "$PACKAGERUNTIME" == "linux-arm" ]]; then
      acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-armv7l.tar.gz" node20 fix_nested_dir
  fi
 +
 +if [[ "$PACKAGERUNTIME" == "linux-ppc64le" ]]; then
 +    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-ppc64le.tar.gz" node20 fix_nested_dir
++    acquireExternalTool "$NODE_URL/v${NODE24_VERSION}/node-v${NODE24_VERSION}-linux-ppc64le.tar.gz" node24 fix_nested_dir
 +fi
 +
 +if [[ "$PACKAGERUNTIME" == "linux-s390x" ]]; then
 +    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-s390x.tar.gz" node20 fix_nested_dir
++    acquireExternalTool "$NODE_URL/v${NODE24_VERSION}/node-v${NODE24_VERSION}-linux-s390x.tar.gz" node24 fix_nested_dir
 +fi
 \ No newline at end of file
 diff --git a/src/Misc/layoutroot/config.sh b/src/Misc/layoutroot/config.sh

--- a/patches/runner-sdk8-s390x.patch
+++ b/patches/runner-sdk8-s390x.patch
@@ -16,20 +16,22 @@ index 9c069b12..d26b0dc2 100644
    <!-- Set TRACE/DEBUG vars -->
    <PropertyGroup>
 diff --git a/src/Misc/externals.sh b/src/Misc/externals.sh
-index ca8f6c28..5d06f9be 100755
+index ca8f6c28..07d08a0e 100755
 --- a/src/Misc/externals.sh
 +++ b/src/Misc/externals.sh
-@@ -187,3 +187,11 @@ fi
+@@ -187,3 +187,13 @@ fi
  if [[ "$PACKAGERUNTIME" == "linux-arm" ]]; then
      acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-armv7l.tar.gz" node20 fix_nested_dir
  fi
 +
 +if [[ "$PACKAGERUNTIME" == "linux-ppc64le" ]]; then
 +    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-ppc64le.tar.gz" node20 fix_nested_dir
++    acquireExternalTool "$NODE_URL/v${NODE24_VERSION}/node-v${NODE24_VERSION}-linux-ppc64le.tar.gz" node24 fix_nested_dir
 +fi
 +
 +if [[ "$PACKAGERUNTIME" == "linux-s390x" ]]; then
 +    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-s390x.tar.gz" node20 fix_nested_dir
++    acquireExternalTool "$NODE_URL/v${NODE24_VERSION}/node-v${NODE24_VERSION}-linux-s390x.tar.gz" node24 fix_nested_dir
 +fi
 \ No newline at end of file
 diff --git a/src/Misc/layoutroot/config.sh b/src/Misc/layoutroot/config.sh

--- a/patches/runner-sdk8-x86_64.patch
+++ b/patches/runner-sdk8-x86_64.patch
@@ -16,20 +16,22 @@ index 9c069b12..d26b0dc2 100644
    <!-- Set TRACE/DEBUG vars -->
    <PropertyGroup>
 diff --git a/src/Misc/externals.sh b/src/Misc/externals.sh
-index ca8f6c28..5d06f9be 100755
+index ca8f6c28..07d08a0e 100755
 --- a/src/Misc/externals.sh
 +++ b/src/Misc/externals.sh
-@@ -187,3 +187,11 @@ fi
+@@ -187,3 +187,13 @@ fi
  if [[ "$PACKAGERUNTIME" == "linux-arm" ]]; then
      acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-armv7l.tar.gz" node20 fix_nested_dir
  fi
 +
 +if [[ "$PACKAGERUNTIME" == "linux-ppc64le" ]]; then
 +    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-ppc64le.tar.gz" node20 fix_nested_dir
++    acquireExternalTool "$NODE_URL/v${NODE24_VERSION}/node-v${NODE24_VERSION}-linux-ppc64le.tar.gz" node24 fix_nested_dir
 +fi
 +
 +if [[ "$PACKAGERUNTIME" == "linux-s390x" ]]; then
 +    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-s390x.tar.gz" node20 fix_nested_dir
++    acquireExternalTool "$NODE_URL/v${NODE24_VERSION}/node-v${NODE24_VERSION}-linux-s390x.tar.gz" node24 fix_nested_dir
 +fi
 \ No newline at end of file
 diff --git a/src/Misc/layoutroot/config.sh b/src/Misc/layoutroot/config.sh


### PR DESCRIPTION
### Changes

- Updated existing patches to ensure compatibility with NODE24.
- Extended build and runtime support for **ppc64le** and **s390x** platforms.
- Verified that the changes do not break existing functionality on other supported architectures.