### PR TITLE
fix: remove Release tag from tests to resolve runner binary build failures

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -38,7 +38,7 @@ jobs:
           cd /tmp/runner/src
           sudo ./dev.sh layout Release
           sudo ./dev.sh package Release
-          sudo ./dev.sh test Release
+          sudo ./dev.sh test
       
       - name: Installing runner
         run: |

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -39,7 +39,7 @@ jobs:
           cd /tmp/runner/src
           sudo ./dev.sh layout Release
           sudo ./dev.sh package Release
-          sudo ./dev.sh test Release
+          sudo ./dev.sh test
       
       - name: Installing runner
         run: |


### PR DESCRIPTION
### What
- Removed the `Release` tag from tests.

### Why
- The `Release` tag was causing runner binary build failures.
- Removing it ensures that the test suite runs correctly without impacting the build process.

### Impact
- Fixes runner binary build failures.
- Improves build stability going forward.
