### PR TITLE
Update LXD installation to pin to LTS version and to hold autorefresh

### DIFF
--- a/images/ubuntu/scripts/build/install-lxd.sh
+++ b/images/ubuntu/scripts/build/install-lxd.sh
@@ -5,15 +5,23 @@
 ################################################################################
 source $HELPER_SCRIPTS/install.sh
 
-# Install LXD using snap
-echo "Installing LXD using snap..."
-sudo snap install lxd
+# Install 5.21 LTS LXD version using snap
+echo "Installing LXD version 5.21 using snap..."
+sudo snap install lxd --channel="5.21/stable"
+
+echo "Printing LXD info..."
+lxc info
+
+echo "Checking list of refreshable snaps..."
+sudo snap refresh --list
 
 echo "Checking the status of snap.lxd.daemon..."
 ensure_service_is_active snap.lxd.daemon
+
+# Hold the autorefresh for LXD as it can cause unwanted service-disruptions 
+sudo snap refresh --hold lxd
 
 # Initialize LXD
 echo "Initializing LXD..."
 cat $INSTALLER_SCRIPT_FOLDER/lxd-preseed.yaml | sudo -i lxd init --preseed
 echo "LXD is ready to use!"
-


### PR DESCRIPTION
## Summary 
This PR disables auto-refresh to the LXD snap to avoid any unplanned service disruptions caused due to snap refresh.

According to the [official snapd documentation](https://snapcraft.io/docs/managing-updates), snaps are subject to 4 "autorefreshes" every 24h to keep the packages updated and in-sync with their databases. This can cause issues in production environments as the update process includes re-establishing connectivity with the LXD `unix.socket` file.  

To prevent this from affecting us, this PR introduces two changes. 
- Pinning the LXD version to an LTS version (5.21 at the time of submitting this PR)
- Holding the auto-refresh until **90** days which is the maximum amount for which the refresh can be held, post which the auto-refresh is mandatory and cannot be stopped. 