### PR TITLE
fix(build): add 'Release' argument to layout and package commands

### DIFF
--- a/dockerfiles/Dockerfile.centos.9
+++ b/dockerfiles/Dockerfile.centos.9
@@ -22,8 +22,8 @@ RUN     cd /tmp && \
         sed -i'' -e /version/s/8......\"$/8.0.100\"/ src/global.json
 
 RUN     cd /tmp/runner/src && \
-        ./dev.sh layout && \
-        ./dev.sh package && \
+        ./dev.sh layout Release && \
+        ./dev.sh package Release && \
         ./dev.sh test && \
         rm -rf /root/.dotnet /root/.nuget
 

--- a/dockerfiles/Dockerfile.ubuntu.22.04
+++ b/dockerfiles/Dockerfile.ubuntu.22.04
@@ -24,8 +24,8 @@ RUN     cd /tmp && \
         sed -i'' -e /version/s/8......\"$/8.0.100\"/ src/global.json
         
 RUN     cd /tmp/runner/src && \
-        ./dev.sh layout && \
-        ./dev.sh package && \
+        ./dev.sh layout Release && \
+        ./dev.sh package Release && \
         ./dev.sh test && \
         rm -rf /root/.dotnet /root/.nuget
 

--- a/dockerfiles/Dockerfile.ubuntu.24.04
+++ b/dockerfiles/Dockerfile.ubuntu.24.04
@@ -24,8 +24,8 @@ RUN     cd /tmp && \
         sed -i'' -e /version/s/8......\"$/8.0.100\"/ src/global.json
 
 RUN     cd /tmp/runner/src && \
-        ./dev.sh layout && \
-        ./dev.sh package && \
+        ./dev.sh layout Release && \
+        ./dev.sh package Release && \
         ./dev.sh test && \
         rm -rf /root/.dotnet /root/.nuget
 

--- a/dockerfiles/Dockerfile.ubuntu.24.10
+++ b/dockerfiles/Dockerfile.ubuntu.24.10
@@ -24,8 +24,8 @@ RUN     cd /tmp && \
         sed -i'' -e /version/s/8......\"$/8.0.100\"/ src/global.json
 
 RUN     cd /tmp/runner/src && \
-        ./dev.sh layout && \
-        ./dev.sh package && \
+        ./dev.sh layout Release && \
+        ./dev.sh package Release && \
         ./dev.sh test && \
         rm -rf /root/.dotnet /root/.nuget
 


### PR DESCRIPTION
**Description:** 
This PR updates the build scripts to ensure that the `Release` argument is explicitly passed to both the layout and package commands.

**Changes:**

- Updated build scripts to include `Release` argument for:

  - **layout command**
  - **package command**