### PR TITLE
fix(build_image): ensure cleanup by deleting ephemeral build container after use

### DIFF
--- a/scripts/lxd.sh
+++ b/scripts/lxd.sh
@@ -152,6 +152,7 @@ build_image() {
   
   # Before exiting successfully, clear the trap so it doesn't run again on the main script's exit.
   trap - INT TERM EXIT
+  lxc delete -f "${BUILD_CONTAINER}"
   return 0
 }
 


### PR DESCRIPTION
**Description:** 
This PR fixes a cleanup issue in the build process by ensuring that the ephemeral build container is deleted once it has completed its purpose.

- Added logic to remove the build container immediately after use.
- Prevents accumulation of dangling containers during repeated builds.
- Improves reliability and keeps the build environment clean.