### PR TITLE
Test existence of file before attempting any modifications.

### DIFF
--- a/images/ubuntu/scripts/build/configure-environment.sh
+++ b/images/ubuntu/scripts/build/configure-environment.sh
@@ -57,7 +57,9 @@ touch $netfilter_rule
 echo 'ACTION=="add", SUBSYSTEM=="module", KERNEL=="nf_conntrack", RUN+="/usr/sbin/sysctl net.netfilter.nf_conntrack_tcp_be_liberal=1"' | tee -a $netfilter_rule
 
 # Disable motd updates metadata
-sed -i 's/ENABLED=1/ENABLED=0/g' /etc/default/motd-news
+if [[ -f /etc/default/motd-news ]]; then
+    sed -i 's/ENABLED=1/ENABLED=0/g' /etc/default/motd-news
+fi
 
 if [[ -f "/etc/fwupd/daemon.conf" ]]; then
     sed -i 's/UpdateMotd=true/UpdateMotd=false/g' /etc/fwupd/daemon.conf


### PR DESCRIPTION
## Summary 

The current `configure-environment.sh` file does not check for existence of `motd-news` file in ubuntu hosts before attempting to disable it. This can cause the build to fail in environments where the file doesn't exist at all, as seen in #20 

This PR introduces the fix for it by simply testing for the file's existence before attempting to make any modifications. 