### PR TITLE
fix: Update Ruby installer

### DIFF
--- a/images/ubuntu/scripts/build/install-ruby.sh
+++ b/images/ubuntu/scripts/build/install-ruby.sh
@@ -27,9 +27,9 @@ fi
 install_dpkgs libz-dev openssl libssl-dev
 
 echo "Install Ruby from toolset..."
-package_tar_names=$(curl -fsSL "https://api.github.com/repos/ruby/ruby-builder/releases/latest" | jq -r '.assets[].name')
 toolset_versions=$(get_toolset_value '.toolcache[] | select(.name | contains("Ruby")) | .versions[]')
 platform_version=$(get_toolset_value '.toolcache[] | select(.name | contains("Ruby")) | .platform_version')
+arch=$(get_toolset_value '.toolcache[] | select(.name | contains("Ruby")) | .arch')
 ruby_path="$AGENT_TOOLSDIRECTORY/Ruby"
 
 echo "Check if Ruby hostedtoolcache folder exist..."
@@ -38,7 +38,8 @@ if [[ ! -d $ruby_path ]]; then
 fi
 
 for toolset_version in ${toolset_versions[@]}; do
-    package_tar_name=$(echo "$package_tar_names" | grep "^ruby-${toolset_version}-ubuntu-${platform_version}.tar.gz$" | sort -V | tail -1)
+    download_url=$(resolve_github_release_asset_url "ruby/ruby-builder" "test(\"ruby-${toolset_version}-ubuntu-${platform_version}-${arch}.tar.gz\")" "${toolset_version}" "false" "true")
+    package_tar_name="${download_url##*/}"
     ruby_version=$(echo "$package_tar_name" | cut -d'-' -f 2)
     ruby_version_path="$ruby_path/$ruby_version"
 
@@ -46,7 +47,6 @@ for toolset_version in ${toolset_versions[@]}; do
     mkdir -p $ruby_version_path
 
     echo "Downloading tar archive $package_tar_name"
-    download_url="https://github.com/ruby/ruby-builder/releases/download/toolcache/${package_tar_name}"
     package_archive_path=$(download_with_retry "$download_url")
 
     echo "Expand '$package_tar_name' to the '$ruby_version_path' folder"


### PR DESCRIPTION
### Description

This fixes the blocker on the Ubuntu image 22.04 builds by updating the Ruby installation to accommodate the changes Ruby has made to their release structure. This fix mirrors the implementation used in the official GitHub Actions ruby installer script.

