### PR TITLE
fix(lxd): Improve LXD Snap Management and Stability

### DIFF
--- a/images/centos/scripts/build/install-lxd.sh
+++ b/images/centos/scripts/build/install-lxd.sh
@@ -3,16 +3,40 @@
 ##  File:  install-lxd.sh
 ##  Desc:  Install lxd
 ################################################################################
-source $HELPER_SCRIPTS/install.sh
+# shellcheck disable=SC1091
+source "$HELPER_SCRIPTS"/install.sh
 
-# Install LXD using snap
-echo "Installing LXD using snap..."
-sudo snap install lxd
+LATEST_LTS_CHANNEL=$(snap info lxd | grep -E '(^\s*[0-9]+\.0/stable)' | awk '{print $1}' | sed 's|/stable:||' | sort -rV | head -n 1)
+
+if [ -n "$LATEST_LTS_CHANNEL" ]; then
+    echo "The latest LTS channel is: ${LATEST_LTS_CHANNEL}/stable"
+else
+    echo "Could not determine the latest LTS channel."
+fi
+
+# Install 5.21 LTS LXD version using snap
+echo "Installing LXD version ${LATEST_LTS_CHANNEL} using snap..."
+sudo snap install lxd --channel="${LATEST_LTS_CHANNEL}/stable"
+
+echo "Printing LXD info..."
+lxc info
+
+echo "Checking list of refreshable snaps..."
+sudo snap refresh --list
 
 echo "Checking the status of snap.lxd.daemon..."
 ensure_service_is_active snap.lxd.daemon
 
-# Initialize LXD
-echo "Initializing LXD..."
-cat $INSTALLER_SCRIPT_FOLDER/lxd-preseed.yaml | sudo -i lxd init --preseed
-echo "LXD is ready to use!"
+# Hold the autorefresh for LXD as it can cause unwanted service-disruptions 
+sudo snap refresh --hold lxd
+
+# Initialize LXD using the preseed configuration file for automated setup.
+echo "Initializing LXD with preseed configuration..."
+if [[ -f "$INSTALLER_SCRIPT_FOLDER/lxd-preseed.yaml" ]]; then
+    cat "$INSTALLER_SCRIPT_FOLDER/lxd-preseed.yaml" | sudo lxd init --preseed
+else
+    echo "Warning: lxd-preseed.yaml not found. Initializing with defaults."
+    sudo lxd init --auto
+fi
+
+echo "LXD installation and initialization are complete!"

--- a/images/ubuntu/scripts/build/install-lxd.sh
+++ b/images/ubuntu/scripts/build/install-lxd.sh
@@ -3,11 +3,20 @@
 ##  File:  install-lxd.sh
 ##  Desc:  Install lxd
 ################################################################################
-source $HELPER_SCRIPTS/install.sh
+# shellcheck disable=SC1091
+source "$HELPER_SCRIPTS"/install.sh
+
+LATEST_LTS_CHANNEL=$(snap info lxd | grep -E '(^\s*[0-9]+\.0/stable)' | awk '{print $1}' | sed 's|/stable:||' | sort -rV | head -n 1)
+
+if [ -n "$LATEST_LTS_CHANNEL" ]; then
+    echo "The latest LTS channel is: ${LATEST_LTS_CHANNEL}/stable"
+else
+    echo "Could not determine the latest LTS channel."
+fi
 
 # Install 5.21 LTS LXD version using snap
-echo "Installing LXD version 5.21 using snap..."
-sudo snap install lxd --channel="5.21/stable"
+echo "Installing LXD version ${LATEST_LTS_CHANNEL} using snap..."
+sudo snap install lxd --channel="${LATEST_LTS_CHANNEL}/stable"
 
 echo "Printing LXD info..."
 lxc info
@@ -21,7 +30,13 @@ ensure_service_is_active snap.lxd.daemon
 # Hold the autorefresh for LXD as it can cause unwanted service-disruptions 
 sudo snap refresh --hold lxd
 
-# Initialize LXD
-echo "Initializing LXD..."
-cat $INSTALLER_SCRIPT_FOLDER/lxd-preseed.yaml | sudo -i lxd init --preseed
-echo "LXD is ready to use!"
+# Initialize LXD using the preseed configuration file for automated setup.
+echo "Initializing LXD with preseed configuration..."
+if [[ -f "$INSTALLER_SCRIPT_FOLDER/lxd-preseed.yaml" ]]; then
+    cat "$INSTALLER_SCRIPT_FOLDER/lxd-preseed.yaml" | sudo lxd init --preseed
+else
+    echo "Warning: lxd-preseed.yaml not found. Initializing with defaults."
+    sudo lxd init --auto
+fi
+
+echo "LXD installation and initialization are complete!"

--- a/scripts/lxd.sh
+++ b/scripts/lxd.sh
@@ -39,7 +39,34 @@ ensure_lxd() {
             exit 1
         fi
     else
-        echo "LXD is already installed. Version: $(lxd --version)"
+        echo "LXD is already installed. Checking its version..."
+
+        LATEST_LTS_CHANNEL=$(snap info lxd | grep -E '(^\s*[0-9]+\.0/stable)' | awk '{print $1}' | sed 's|/stable:||' | sort -rV | head -n 1)
+
+        # Get the currently tracked channel from the snap list output.
+        CURRENT_LTS_CHANNEL=$(snap list lxd | awk 'NR==2 {print $4}' | sed 's|/stable.*||')
+
+        echo "Currently installed channel: ${CURRENT_LTS_CHANNEL}"
+        echo "Latest available LTS channel: ${LATEST_LTS_CHANNEL}"
+
+        # Compare the current channel with the latest available LTS channel.
+        if [ "$CURRENT_LTS_CHANNEL" != "$LATEST_LTS_CHANNEL" ]; then
+            echo
+            echo "An upgrade is recommended."
+            echo "To prevent disruption to your existing setup, please upgrade manually."
+            echo "Run the following command to switch to the latest LTS channel:"
+            echo
+            echo "  sudo snap refresh lxd --channel=${LATEST_LTS_CHANNEL}/stable"
+            echo
+            echo "Note: Always back up your data before performing a channel switch."
+        else
+            echo "You are already on the latest available LXD LTS channel. No action needed."
+        fi
+        echo "Checking list of refreshable snaps..."
+        sudo snap refresh --list
+  
+        # Hold the autorefresh for LXD
+        sudo snap refresh --hold lxd
     fi
 }
 


### PR DESCRIPTION
### **Description**
- **Hold Snap Autorefresh:**  The script now executes a `snap refresh --hold lxd` command after installation. This disables automatic background refreshes, ensuring that all LXD upgrades are deliberate actions performed by an operator during a planned maintenance window.
- **Remove Static Channel Pinning:**  The installation command has been updated to remove the hard-coded version (e.g., `5.21`). This allows the script to install from the latest stable channel (`stable`) by default, streamlining the upgrade process significantly. Upgrades can now be managed via standard snap commands on the host without requiring code modifications.

### Fixes: #29 