### PR TITLE
refactor(dockerfiles): Standardize Dockerfiles across distros

### DIFF
--- a/dockerfiles/Dockerfile.centos.9
+++ b/dockerfiles/Dockerfile.centos.9
@@ -1,16 +1,21 @@
 # FROM    quay.io/centos/centos:stream9
 FROM    almalinux:9
 
-ARG     RUNNERREPO="https://github.com/actions/runner" RUNNERPATCH SDK=8 SDK_VERSION ARCH
+ARG     RUNNERREPO="https://github.com/actions/runner" 
+ARG     RUNNERPATCH
+ARG     SDK=8
+ARG     ARCH
 
 RUN     echo "tsflags=nodocs" >>/etc/dnf/dnf.conf
 
 RUN     dnf update -y -q && \
-        dnf install -y -q wget git which langpacks-en glibc-all-langpacks sudo shadow-utils tar
-        
-RUN     dnf install -y -q dotnet-sdk-${SDK}.0 && \
-        SDK_VERSION=`dotnet --version` && \
-        echo "Using SDK - ${SDK_VERSION}"
+        dnf install -y -q \
+            wget git which langpacks-en glibc-all-langpacks sudo shadow-utils tar dotnet-sdk-${SDK}.0 \
+            cmake make automake autoconf m4 gcc gcc-c++ libtool epel-release && \
+        dnf clean all && \
+        rm -rf /var/cache/dnf/*
+
+RUN     echo "Using SDK - $(dotnet --version)"
 
 ADD    ${RUNNERPATCH} /tmp/runner.patch
 
@@ -34,16 +39,13 @@ RUN     useradd -c 'Action Runner' -m -s /bin/bash runner && \
 
 RUN     mkdir -p /opt/runner-cache && \
         tar -xf /tmp/runner/_package/*.tar.gz -C /opt/runner-cache && \
-        chown -R  runner:runner /opt/runner-cache && \
-        su -c "/opt/runner-cache/config.sh --version"  runner
+        chown -R runner:runner /opt/runner-cache && \
+        sudo -u runner /opt/runner-cache/config.sh --version
 
-RUN     dnf install -y -q cmake make automake autoconf m4 gcc gcc-c++ libtool epel-release
+RUN     rm -rf /tmp/runner /tmp/runner.patch
 
-RUN     rm -rf /tmp/runner /var/cache/dnf/* /tmp/runner.patch \
-        dnf clean all
-    
-USER     runner
+USER    runner
 
 EXPOSE  443
 
-CMD     /bin/bash
+CMD     ["/bin/bash"]

--- a/dockerfiles/Dockerfile.ubuntu.22.04
+++ b/dockerfiles/Dockerfile.ubuntu.22.04
@@ -1,6 +1,9 @@
 FROM    ubuntu:22.04
 
-ARG     RUNNERREPO="https://github.com/actions/runner" RUNNERPATCH SDK_VERSION ARCH
+ARG     RUNNERREPO="https://github.com/actions/runner"
+ARG     RUNNERPATCH
+ARG     SDK=8
+ARG     ARCH
 
 ENV     DEBIAN_FRONTEND=noninteractive
 
@@ -9,10 +12,13 @@ COPY    ../scripts/assets/99synaptics /etc/apt/apt.conf.d/
 COPY    ../scripts/assets/01-nodoc /etc/dpkg/dpkg.cfg.d/
 
 RUN     apt-get -qq update -y && \
-        apt-get -qq -y install wget git sudo curl dotnet-sdk-8.0 && \
-        apt autoclean
+        apt-get -qq -y install --no-install-recommends \
+            wget git sudo curl dotnet-sdk-${SDK}.0 \
+            cmake make automake autoconf m4 gcc-12-base libtool && \
+        apt-get autoclean && \
+        rm -rf /var/lib/apt/lists/*
 
-RUN     echo "Using SDK - `dotnet --version`"
+RUN     echo "Using SDK - $(dotnet --version)"
 
 ADD     ${RUNNERPATCH} /tmp/runner.patch
 
@@ -22,7 +28,7 @@ RUN     cd /tmp && \
         git checkout $(git tag --sort=-v:refname | grep '^v[0-9]' | head -n1) && \
         git apply --whitespace=nowarn /tmp/runner.patch && \
         sed -i'' -e /version/s/8......\"$/8.0.100\"/ src/global.json
-        
+
 RUN     cd /tmp/runner/src && \
         ./dev.sh layout Release && \
         ./dev.sh package Release && \
@@ -36,15 +42,13 @@ RUN     useradd -c 'Action Runner' -m -s /bin/bash runner && \
 
 RUN     mkdir -p /opt/runner-cache && \
         tar -xf /tmp/runner/_package/*.tar.gz -C /opt/runner-cache && \
-        chown -R  runner:runner /opt/runner-cache && \
-        su -c "/opt/runner-cache/config.sh --version" runner
-
-RUN     apt-get -qq -y install cmake make automake autoconf m4 gcc-12-base libtool
+        chown -R runner:runner /opt/runner-cache && \
+        sudo -u runner /opt/runner-cache/config.sh --version
 
 RUN     rm -rf /tmp/runner /tmp/runner.patch
-    
+
 USER    runner
 
 EXPOSE  443
 
-CMD     /bin/bash
+CMD     ["/bin/bash"]

--- a/dockerfiles/Dockerfile.ubuntu.24.04
+++ b/dockerfiles/Dockerfile.ubuntu.24.04
@@ -1,6 +1,9 @@
 FROM    ubuntu:24.04
 
-ARG     RUNNERREPO="https://github.com/actions/runner" RUNNERPATCH SDK_VERSION ARCH
+ARG     RUNNERREPO="https://github.com/actions/runner"
+ARG     RUNNERPATCH
+ARG     SDK=8
+ARG     ARCH
 
 ENV     DEBIAN_FRONTEND=noninteractive
 
@@ -9,10 +12,13 @@ COPY    ../scripts/assets/99synaptics /etc/apt/apt.conf.d/
 COPY    ../scripts/assets/01-nodoc /etc/dpkg/dpkg.cfg.d/
 
 RUN     apt-get -qq update -y && \
-        apt-get -qq -y install wget git sudo curl dotnet-sdk-8.0 && \
-        apt autoclean
+        apt-get -qq -y install --no-install-recommends \
+            wget git sudo curl dotnet-sdk-${SDK}.0 \
+            cmake make automake autoconf m4 gcc-12-base libtool && \
+        apt-get autoclean && \
+        rm -rf /var/lib/apt/lists/*
 
-RUN     echo "Using SDK - `dotnet --version`"
+RUN     echo "Using SDK - $(dotnet --version)"
 
 ADD     ${RUNNERPATCH} /tmp/runner.patch
 
@@ -36,15 +42,13 @@ RUN     useradd -c 'Action Runner' -m -s /bin/bash runner && \
 
 RUN     mkdir -p /opt/runner-cache && \
         tar -xf /tmp/runner/_package/*.tar.gz -C /opt/runner-cache && \
-        chown -R  runner:runner /opt/runner-cache && \
-        su -c "/opt/runner-cache/config.sh --version" runner
-
-RUN     apt-get -qq -y install cmake make automake autoconf m4 gcc-12-base libtool
+        chown -R runner:runner /opt/runner-cache && \
+        sudo -u runner /opt/runner-cache/config.sh --version
 
 RUN     rm -rf /tmp/runner /tmp/runner.patch
-    
+
 USER    runner
 
 EXPOSE  443
 
-CMD     /bin/bash
+CMD     ["/bin/bash"]


### PR DESCRIPTION
**Description:**

This PR standardizes the Dockerfiles for Ubuntu 24.04, 22.04, and CentOS 9.

The main goal is to ensure consistent build steps, package installation, and environment variable settings across all supported distributions, which will make future maintenance easier.

**How to Test:**

1. Review the updated `Dockerfile`s to confirm consistency.
2. Build the images to confirm they complete successfully.