### PR TITLE
fix(PATH): Correct runner user PATH for root-installed binaries

### DIFF
--- a/images/centos/scripts/build/configure-runner.sh
+++ b/images/centos/scripts/build/configure-runner.sh
@@ -45,14 +45,6 @@ install_runner() {
     header "Installing runner"
     sudo mkdir -p /opt/runner-cache
     sudo tar -xf /tmp/runner/_package/*.tar.gz -C /opt/runner-cache
-
-    # Create runner user if not exists
-    if ! id -u runner >/dev/null 2>&1; then
-        sudo useradd -r -m -L -d /home/runner -s /bin/bash runner
-    fi
-
-    sudo chown -R runner:runner /opt/runner-cache
-    sudo -u runner /opt/runner-cache/config.sh --version
 }
 
 pre_cleanup() {

--- a/images/ubuntu/scripts/build/configure-runner.sh
+++ b/images/ubuntu/scripts/build/configure-runner.sh
@@ -45,14 +45,6 @@ install_runner() {
     header "Installing runner"
     sudo mkdir -p /opt/runner-cache
     sudo tar -xf /tmp/runner/_package/*.tar.gz -C /opt/runner-cache
-
-    # Create runner user if not exists
-    if ! id -u runner >/dev/null 2>&1; then
-        sudo useradd -r -m -L -d /home/runner -s /bin/bash runner
-    fi
-
-    sudo chown -R runner:runner /opt/runner-cache
-    sudo -u runner /opt/runner-cache/config.sh --version
 }
 
 pre_cleanup() {

--- a/scripts/vm.sh
+++ b/scripts/vm.sh
@@ -42,6 +42,10 @@ msg "Copy the gha-service unit file into gha-builder"
 cp -r "${BUILD_PREREQS_PATH}"/assets/gha-runner.service "/etc/systemd/system/gha-runner.service"
 chmod -R 0755 /etc/systemd/system/gha-runner.service
 
-sudo bash -c 'id -u runner >/dev/null 2>&1 || (useradd -c "Action Runner" -m runner && usermod -L runner && echo "runner  ALL=(ALL)       NOPASSWD: ALL" >/etc/sudoers.d/runner)'
+sudo bash -c 'exec "$@"' _ "${HELPER_SCRIPTS}/setup_install.sh" "${IMAGE_OS}" "${IMAGE_VERSION}" "${WORKER_TYPE}" "${WORKER_CPU}" "${SETUP}"
 
-sudo bash -c "${HELPER_SCRIPTS}/setup_install.sh ${IMAGE_OS} ${IMAGE_VERSION} ${SETUP}"
+sudo bash -c 'id -u runner >/dev/null 2>&1 || (useradd -c "Action Runner" -m -s /bin/bash runner && usermod -L runner && echo "runner ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/runner && chmod 440 /etc/sudoers.d/runner)'
+
+sudo bash -c "usermod -aG adm,users,systemd-journal,docker,lxd runner"
+
+sudo su -c "find /opt/post-generation -mindepth 1 -maxdepth 1 -type f -name '*.sh' -exec bash {} \;"


### PR DESCRIPTION
**Description:**

This PR fixes a bug where binaries installed by the `root` user were not being added to the `$PATH` for the non-privileged `runner` user.

This commit updates the environment setup to ensure all necessary binary paths are available to the `runner`, allowing them to execute tools installed system-wide.

**How to Test:**

1. Build the image (using the changes from this branch).
2. Run a container and `exec` into it as the `runner` user.
3. Run `echo $PATH` and verify the new paths are present.
4. Try to execute one of the binaries that was previously failing.

**Closes**
- https://github.com/IBM/actionspz/issues/45