### PR TITLE
fix(binaries): Remove x86 binaries from ppc64le/s390x images

### DIFF
--- a/images/ubuntu/scripts/build/install-azcopy.sh
+++ b/images/ubuntu/scripts/build/install-azcopy.sh
@@ -8,6 +8,16 @@
 # shellcheck disable=SC1091
 source "$HELPER_SCRIPTS"/install.sh
 
+# Set architecture-specific variables using a case statement for clarity
+case "$ARCH" in
+    "ppc64le" | "s390x")
+        echo "No actions defined for $ARCH architecture."
+        exit 0
+        ;;
+    *)
+        ;;
+esac
+
 # Install AzCopy10
 archive_path=$(download_with_retry "https://aka.ms/downloadazcopy-v10-linux")
 tar xzf "$archive_path" --strip-components=1 -C /tmp

--- a/images/ubuntu/scripts/build/install-codeql-bundle.sh
+++ b/images/ubuntu/scripts/build/install-codeql-bundle.sh
@@ -12,9 +12,15 @@ source "$HELPER_SCRIPTS"/install.sh
 case "$ARCH" in
     "x86_64")
         package_arch="x64"
+        bundle_platform_name="linux64"
+        ;;
+    "aarch64")
+        package_arch="aarch64"
+        bundle_platform_name="linux-aarch64"
         ;;
     *)
-        package_arch="$ARCH"
+        echo "No actions defined for $ARCH architecture."
+        exit 0
         ;;
 esac
 
@@ -41,7 +47,7 @@ bundle_tag_name="codeql-bundle-v$bundle_version"
 echo "Downloading CodeQL bundle $bundle_version..."
 # Note that this is the all-platforms CodeQL bundle, to support scenarios where customers run
 # different operating systems within containers.
-codeql_archive=$(download_with_retry "https://github.com/github/codeql-action/releases/download/$bundle_tag_name/codeql-bundle-linux64.tar.gz")
+codeql_archive=$(download_with_retry "https://github.com/github/codeql-action/releases/download/$bundle_tag_name/codeql-bundle-${bundle_platform_name}.tar.gz")
 
 codeql_toolcache_path="$AGENT_TOOLSDIRECTORY/CodeQL/$bundle_version/${package_arch}"
 mkdir -p "$codeql_toolcache_path"

--- a/images/ubuntu/scripts/build/install-ninja.sh
+++ b/images/ubuntu/scripts/build/install-ninja.sh
@@ -8,6 +8,16 @@
 # shellcheck disable=SC1091
 source "$HELPER_SCRIPTS"/install.sh
 
+# Set architecture-specific variables using a case statement for clarity
+case "$ARCH" in
+    "ppc64le" | "s390x")
+        install_dpkgs ninja-build
+        exit 0
+        ;;
+    *)
+        ;;
+esac
+
 # Install ninja
 download_url=$(resolve_github_release_asset_url "ninja-build/ninja" "endswith(\"ninja-linux.zip\")" "latest")
 ninja_binary_path=$(download_with_retry "${download_url}")

--- a/images/ubuntu/scripts/build/install-ruby.sh
+++ b/images/ubuntu/scripts/build/install-ruby.sh
@@ -23,6 +23,17 @@ fi
 # Install Ruby requirements
 install_dpkgs libz-dev openssl libssl-dev
 
+# Set architecture-specific variables using a case statement for clarity
+# shellcheck disable=SC2153
+case "$ARCH" in
+    "ppc64le" | "s390x")
+        echo "Skipping Ruby installation from toolset on $ARCH architecture."
+        exit 0
+        ;;
+    *)
+        ;;
+esac
+
 echo "Install Ruby from toolset..."
 toolset_versions=$(get_toolset_value '.toolcache[] | select(.name | contains("Ruby")) | .versions[]')
 platform_version=$(get_toolset_value '.toolcache[] | select(.name | contains("Ruby")) | .platform_version')


### PR DESCRIPTION
**Description:**

This PR cleans up the multi-arch builds for `ppc64le` and `s390x`.

The builds were incorrectly packaging x86-specific binaries into these non-x86 images. This change removes the incorrect-architecture binaries, reducing image size and preventing potential execution errors.

**How to Test:**

1. Build the `ppc64le` or `s390x` image.
2. Inspect the image filesystem (e.g., using `docker run --rm -it <image> /bin/bash`) to confirm the x86 binaries are no longer present.

**Closes**
- https://github.com/IBM/actionspz/issues/60