### PR TITLE
fix: pin containerd.io to 1.7.27-1 to resolve LXC runc compatibility issue

### DIFF
--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -39,7 +39,13 @@ for package in $components; do
     if [[ $version == "latest" ]]; then
         install_dpkgs --no-install-recommends "$package"
     else
-        version_string=$(apt-cache madison "$package" | awk '{ print $3 }' | grep "$version" | grep "$os_codename" | head -1)
+        version_string=$(apt-cache madison "$package" | grep "$version" | grep "$os_codename" | awk '{ print $3 }' | head -1)
+        
+        if [[ -z "$version_string" ]]; then
+            echo "Error: Could not find version $version for package $package on $os_codename"
+            exit 1
+        fi
+        
         install_dpkgs --no-install-recommends "${package}=${version_string}"
     fi
 done

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -236,7 +236,7 @@
         "components": [
             {
                 "package": "containerd.io",
-                "version": "latest"
+                "version": "1.7.27-1"
             },
             {
                 "package": "docker-ce-cli",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -193,7 +193,7 @@
         "components": [
             {
                 "package": "containerd.io",
-                "version": "latest"
+                "version": "1.7.27-1"
             },
             {
                 "package": "docker-ce-cli",


### PR DESCRIPTION
#### Overview

This PR improves the stability of the Docker installation process in the Ubuntu image builds. It pins the `containerd.io` package to a specific version to ensure build reproducibility and fixes a logic error in the version resolution script to prevent installation failures.

#### Changes

- **Script Logic Fix (`install-docker.sh`):**

  - Reordered the `apt-cache madison` pipeline. Previously, `awk` ran before `grep`, which could potentially extract the wrong column if the output format varied. It now filters by version and codename *before* extracting the version string.
  - Added a validation step to exit immediately if `version_string` is empty, providing a clear error message instead of failing silently or with a cryptic `apt` error.
- **Version Pinning (`toolset-*.json`):**

  - Pinned `containerd.io` to version `1.7.27-1` for both Ubuntu 22.04 and 24.04. This replaces `"latest"`, ensuring that image builds remain deterministic and aren't broken by unexpected upstream updates.