### PR TITLE
feat: Conditional Snap/LXD installation and LXD Debug Mode

### DIFF
--- a/.github/workflows/gaplib_complete_lxd_build.yml
+++ b/.github/workflows/gaplib_complete_lxd_build.yml
@@ -34,5 +34,4 @@ jobs:
 
       - name: Build GAPLIB Image
         run: | 
-          sed -i -E '/install-snap\.sh|install-lxd\.sh|configure-snap\.sh/d' scripts/helpers/setup_install.sh
-          scripts/lxd.sh "${{ matrix.os }}" "${{ matrix.version }}" "" "" "${{ matrix.setup_type }}" --skip-lxd-snapshot
+          scripts/lxd.sh "${{ matrix.os }}" "${{ matrix.version }}" "" "" "${{ matrix.setup_type }}" --skip-snap-lxd --skip-lxd-snapshot 

--- a/scripts/helpers/setup_install.sh
+++ b/scripts/helpers/setup_install.sh
@@ -60,8 +60,6 @@ if [ "$SETUP" == "minimal" ]; then
         "install-git-lfs.sh"
         "install-github-cli.sh"
         "install-python.sh"
-        "install-snap.sh"
-        "install-lxd.sh"
         "install-zstd.sh"
     )
 elif [ "$SETUP" == "complete" ]; then
@@ -115,8 +113,6 @@ elif [ "$SETUP" == "complete" ]; then
             "install-android-sdk.sh"
             "install-pypy.sh"
             "install-python.sh"
-            "install-snap.sh"
-            "install-lxd.sh"
             "install-zstd.sh"
             "install-ninja.sh"
         )
@@ -180,8 +176,6 @@ elif [ "$SETUP" == "complete" ]; then
             "install-android-sdk.sh"
             "install-pypy.sh"
             "install-python.sh"
-            "install-snap.sh"
-            "install-lxd.sh"
             "install-zstd.sh"
             "install-ninja.sh"
         )
@@ -200,13 +194,18 @@ for SCRIPT_FILE in "${SCRIPT_FILES[@]}"; do
     run_script "$SCRIPT_PATH" "DEBIAN_FRONTEND" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH" "IMAGE_FOLDER"
 done
 
+# Install and configure snap and lxd unless skipped
+if [ "${SKIP_SNAP_LXD:-false}" != "true" ]; then
+    run_script "${INSTALLER_SCRIPT_FOLDER}/install-snap.sh" "DEBIAN_FRONTEND" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH" "IMAGE_FOLDER"
+    run_script "${INSTALLER_SCRIPT_FOLDER}/install-lxd.sh" "DEBIAN_FRONTEND" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH" "IMAGE_FOLDER"
+    run_script "${INSTALLER_SCRIPT_FOLDER}/configure-snap.sh" "HELPER_SCRIPTS" "ARCH"
+fi
+
 run_script "${INSTALLER_SCRIPT_FOLDER}/install-docker.sh" "DOCKERHUB_PULL_IMAGES" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH"
     
 run_script "${INSTALLER_SCRIPT_FOLDER}/install-pipx-packages.sh" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH"
 
 run_script "${INSTALLER_SCRIPT_FOLDER}/install-homebrew.sh" "DEBIAN_FRONTEND" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH"
-
-run_script "${INSTALLER_SCRIPT_FOLDER}/configure-snap.sh" "HELPER_SCRIPTS" "ARCH"
 
 # echo 'Rebooting VM...'
 # sudo reboot

--- a/scripts/helpers/setup_vars.sh
+++ b/scripts/helpers/setup_vars.sh
@@ -13,6 +13,7 @@ usage() {
     echo "  5. SETUP_TYPE    (Optional, default: minimal)"
     echo ""
     echo "Flags:"
+    echo "  --skip-snap-lxd         Skip snap and lxd installation and configuration"
     echo "  --skip-lxd-img-export   Skip LXD image export"
     echo "  --skip-lxd-img-primer   Skip LXD image primer"
     echo "  --skip-lxd-publish      Skip LXD publish"
@@ -24,6 +25,7 @@ usage() {
 }
 
 # Initialize Defaults ---
+SKIP_SNAP_LXD=false
 SKIP_LXD_IMG_EXPORT=false
 SKIP_LXD_IMG_PRIMER=false
 SKIP_LXD_PUBLISH=false
@@ -38,6 +40,10 @@ clean_args=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --skip-snap-lxd)
+            # shellcheck disable=SC2034
+            SKIP_SNAP_LXD=true
+            ;;
         --skip-lxd-img-export)
             # shellcheck disable=SC2034
             SKIP_LXD_IMG_EXPORT=true

--- a/scripts/helpers/setup_vars.sh
+++ b/scripts/helpers/setup_vars.sh
@@ -13,6 +13,7 @@ usage() {
     echo "  5. SETUP_TYPE    (Optional, default: minimal)"
     echo ""
     echo "Flags:"
+    echo "  --lxd-debug             Enable LXD debug mode (non-ephemeral containers)"
     echo "  --skip-snap-lxd         Skip snap and lxd installation and configuration"
     echo "  --skip-lxd-img-export   Skip LXD image export"
     echo "  --skip-lxd-img-primer   Skip LXD image primer"
@@ -25,6 +26,7 @@ usage() {
 }
 
 # Initialize Defaults ---
+LXD_DEBUG=false
 SKIP_SNAP_LXD=false
 SKIP_LXD_IMG_EXPORT=false
 SKIP_LXD_IMG_PRIMER=false
@@ -40,6 +42,10 @@ clean_args=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --lxd-debug)
+            # shellcheck disable=SC2034
+            LXD_DEBUG=true
+            ;;
         --skip-snap-lxd)
             # shellcheck disable=SC2034
             SKIP_SNAP_LXD=true


### PR DESCRIPTION
**Description:**

This PR refactors the installation logic for Snap and LXD to make them optional via command-line flags, removing the need for `sed` hacks in CI workflows. Additionally, it introduces a "Debug Mode" for the LXD builder script to facilitate troubleshooting.

**Key Changes:**

**1. Conditional Snap &amp; LXD Installation**

- **`scripts/helpers/setup_install.sh`**: Removed `install-snap.sh` and `install-lxd.sh` from the hardcoded script lists. They are now executed conditionally at the end of the script based on the `SKIP_SNAP_LXD` environment variable.
- **`scripts/helpers/setup_vars.sh`**: Added the `--skip-snap-lxd` argument to set the `SKIP_SNAP_LXD` variable.
-  **`.github/workflows/gaplib_complete_lxd_build.yml`**: Removed the `sed` command that modified `setup_install.sh` in the CI pipeline. Replaced it with the native `--skip-snap-lxd` flag.

**2. LXD Builder Debug Mode**

- **`scripts/lxd.sh`**:

  - Added support for a `--lxd-debug` flag.
  - **Behavior Change:**  When debug mode is enabled, the build container is launched **without** the `--ephemeral` flag.
  - **Cleanup Logic:**  Refactored cleanup into a dedicated `cleanup_builder` function. If debug mode is on, the cleanup trap skips deleting the container, allowing developers to inspect the state after a build failure or completion.

**3. General Cleanup**

- Standardized argument parsing in `setup_vars.sh` for the new flags.