### PR TITLE
ci: Refactor ShellCheck workflow and suppress linting warnings

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,35 +1,24 @@
 name: ShellCheck Lint
 
-# TODO: Include path filters for only .sh files
 on:
   push:
+    branches: [ "main" ]
+    paths: [ "**.sh" ] # Only run if shell files change
+  pull_request:
+    branches: [ "main" ]
+    paths: [ "**.sh" ]
   workflow_dispatch:
-    
 
 jobs:
   shellcheck:
     name: Run ShellCheck
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Install ShellCheck
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y shellcheck
-
-      - name: Find shell scripts
-        run: |
-          echo "Detecting shell scripts..."
-          # list .sh and script files
-          # TODO: Ensure all shell files are checked
-          find . -type f -name "*.sh" > script_list.txt
-
       - name: Run ShellCheck
-        run: |
-          echo "Running ShellCheck on found scripts..."
-
-          # TODO: Currently printing only 'warnings' and 'errors'. Work on refining the scans.
-          shellcheck --severity=error --format=gcc $(cat script_list.txt)
+        uses: ludeeus/action-shellcheck@master
+        with:
+          # Optional: check specific directory
+          scandir: '.'

--- a/images/centos/scripts/build/install-lxd.sh
+++ b/images/centos/scripts/build/install-lxd.sh
@@ -33,6 +33,7 @@ sudo snap refresh --hold lxd
 # Initialize LXD using the preseed configuration file for automated setup.
 echo "Initializing LXD with preseed configuration..."
 if [[ -f "$INSTALLER_SCRIPT_FOLDER/lxd-preseed.yaml" ]]; then
+    # shellcheck disable=SC2002
     cat "$INSTALLER_SCRIPT_FOLDER/lxd-preseed.yaml" | sudo lxd init --preseed
 else
     echo "Warning: lxd-preseed.yaml not found. Initializing with defaults."

--- a/images/ubuntu/scripts/build/install-lxd.sh
+++ b/images/ubuntu/scripts/build/install-lxd.sh
@@ -30,6 +30,7 @@ sudo snap refresh --hold lxd
 # Initialize LXD using the preseed configuration file for automated setup.
 echo "Initializing LXD with preseed configuration..."
 if [[ -f "$INSTALLER_SCRIPT_FOLDER/lxd-preseed.yaml" ]]; then
+    # shellcheck disable=SC2002
     cat "$INSTALLER_SCRIPT_FOLDER/lxd-preseed.yaml" | sudo lxd init --preseed
 else
     echo "Warning: lxd-preseed.yaml not found. Initializing with defaults."


### PR DESCRIPTION
### Description

This PR refactors the existing ShellCheck CI workflow to be more efficient and maintainable, and addresses active linting warnings in the LXD installation scripts.

**Key Changes:**

1. **Workflow Optimization ( **`shellcheck.yml`** ):**

    - **Replaced Manual Steps:**  Removed the manual `apt-get install` and custom `find` logic. Switched to the community standard `ludeeus/action-shellcheck` action.
    - **Path Filtering:**  Added `paths: ["**.sh"]` to the `push` and `pull_request` triggers. This ensures the workflow only runs when shell scripts are actually modified, saving CI resources.
    - **Branch Filtering:**  Explicitly targeted the `main` branch.
2. **Script Fixes ( **`install-lxd.sh`** ):**

    - Added `# shellcheck disable=SC2002` directives to both the CentOS and Ubuntu LXD install scripts.
    - *Context:*  This suppresses the "Useless cat" warning for the `lxd init --preseed` command, preserving the existing pipe syntax preference over input redirection.