### PR TITLE
feat: add --lxd-debug flag to support non-ephemeral container builds

### DIFF
--- a/scripts/helpers/setup_vars.sh
+++ b/scripts/helpers/setup_vars.sh
@@ -13,6 +13,7 @@ usage() {
     echo "  5. SETUP_TYPE    (Optional, default: minimal)"
     echo ""
     echo "Flags:"
+    echo "  --lxd-debug             Enable LXD debug mode (non-ephemeral containers)"
     echo "  --skip-lxd-img-export   Skip LXD image export"
     echo "  --skip-lxd-img-primer   Skip LXD image primer"
     echo "  --skip-lxd-publish      Skip LXD publish"
@@ -24,6 +25,7 @@ usage() {
 }
 
 # Initialize Defaults ---
+LXD_DEBUG=false
 SKIP_LXD_IMG_EXPORT=false
 SKIP_LXD_IMG_PRIMER=false
 SKIP_LXD_PUBLISH=false
@@ -38,6 +40,10 @@ clean_args=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --lxd-debug)
+            # shellcheck disable=SC2034
+            LXD_DEBUG=true
+            ;;
         --skip-lxd-img-export)
             # shellcheck disable=SC2034
             SKIP_LXD_IMG_EXPORT=true


### PR DESCRIPTION
### Description

This PR introduces a new `--lxd-debug` flag to the build scripts. When enabled, this flag launches LXD containers without the `--ephemeral` flag and bypasses the automatic cleanup trap upon script exit.

### Motivation

Currently, build containers are strictly ephemeral. If a build script fails or if we need to inspect the state of the filesystem after a build, the container is immediately destroyed, making troubleshooting difficult. This change allows developers to preserve the container state for manual inspection.

### Key Changes

- **`scripts/helpers/setup_vars.sh`**:

  - Added argument parsing for `--lxd-debug`.
  - Defaults `LXD_DEBUG` to `false` to maintain existing behavior.
- **`scripts/lxd.sh`**:

  - Refactored cleanup logic into a named function `cleanup_builder`.
  - Updated `cleanup_builder` to respect the `LXD_DEBUG` variable (skips deletion if true).
  - Updated `lxc launch` logic: defaults to `--ephemeral`, but switches to persistent containers if debug mode is active.
  - Updated the `trap` to call the new function instead of an inline block.