### PR TITLE
feat: add --skip-snap-lxd flag, fix arg propagation, and remove CI sed workaround

### DIFF
--- a/.github/workflows/gaplib_complete_lxd_build.yml
+++ b/.github/workflows/gaplib_complete_lxd_build.yml
@@ -34,5 +34,4 @@ jobs:
 
       - name: Build GAPLIB Image
         run: | 
-          sed -i -E '/install-snap\.sh|install-lxd\.sh|configure-snap\.sh/d' scripts/helpers/setup_install.sh
-          scripts/lxd.sh "${{ matrix.os }}" "${{ matrix.version }}" "" "" "${{ matrix.setup_type }}" --skip-lxd-snapshot
+          scripts/lxd.sh "${{ matrix.os }}" "${{ matrix.version }}" "" "" "${{ matrix.setup_type }}" --skip-snap-lxd --skip-lxd-snapshot 

--- a/scripts/helpers/setup_install.sh
+++ b/scripts/helpers/setup_install.sh
@@ -60,8 +60,6 @@ if [ "$SETUP" == "minimal" ]; then
         "install-git-lfs.sh"
         "install-github-cli.sh"
         "install-python.sh"
-        "install-snap.sh"
-        "install-lxd.sh"
         "install-zstd.sh"
     )
 elif [ "$SETUP" == "complete" ]; then
@@ -115,8 +113,6 @@ elif [ "$SETUP" == "complete" ]; then
             "install-android-sdk.sh"
             "install-pypy.sh"
             "install-python.sh"
-            "install-snap.sh"
-            "install-lxd.sh"
             "install-zstd.sh"
             "install-ninja.sh"
         )
@@ -180,8 +176,6 @@ elif [ "$SETUP" == "complete" ]; then
             "install-android-sdk.sh"
             "install-pypy.sh"
             "install-python.sh"
-            "install-snap.sh"
-            "install-lxd.sh"
             "install-zstd.sh"
             "install-ninja.sh"
         )
@@ -200,13 +194,18 @@ for SCRIPT_FILE in "${SCRIPT_FILES[@]}"; do
     run_script "$SCRIPT_PATH" "DEBIAN_FRONTEND" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH" "IMAGE_FOLDER"
 done
 
+# Install and configure snap and lxd unless skipped
+if [ "${SKIP_SNAP_LXD:-false}" != "true" ]; then
+    run_script "${INSTALLER_SCRIPT_FOLDER}/install-snap.sh" "DEBIAN_FRONTEND" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH" "IMAGE_FOLDER"
+    run_script "${INSTALLER_SCRIPT_FOLDER}/install-lxd.sh" "DEBIAN_FRONTEND" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH" "IMAGE_FOLDER"
+    run_script "${INSTALLER_SCRIPT_FOLDER}/configure-snap.sh" "HELPER_SCRIPTS" "ARCH"
+fi
+
 run_script "${INSTALLER_SCRIPT_FOLDER}/install-docker.sh" "DOCKERHUB_PULL_IMAGES" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH"
     
 run_script "${INSTALLER_SCRIPT_FOLDER}/install-pipx-packages.sh" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH"
 
 run_script "${INSTALLER_SCRIPT_FOLDER}/install-homebrew.sh" "DEBIAN_FRONTEND" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH"
-
-run_script "${INSTALLER_SCRIPT_FOLDER}/configure-snap.sh" "HELPER_SCRIPTS" "ARCH"
 
 # echo 'Rebooting VM...'
 # sudo reboot

--- a/scripts/helpers/setup_vars.sh
+++ b/scripts/helpers/setup_vars.sh
@@ -14,6 +14,7 @@ usage() {
     echo ""
     echo "Flags:"
     echo "  --lxd-debug             Enable LXD debug mode (non-ephemeral containers)"
+    echo "  --skip-snap-lxd         Skip snap and lxd installation and configuration"
     echo "  --skip-lxd-img-export   Skip LXD image export"
     echo "  --skip-lxd-img-primer   Skip LXD image primer"
     echo "  --skip-lxd-publish      Skip LXD publish"
@@ -26,6 +27,7 @@ usage() {
 
 # Initialize Defaults ---
 LXD_DEBUG=false
+SKIP_SNAP_LXD=false
 SKIP_LXD_IMG_EXPORT=false
 SKIP_LXD_IMG_PRIMER=false
 SKIP_LXD_PUBLISH=false
@@ -37,28 +39,39 @@ PATCH_FILE="${PATCH_FILE:-runner-sdk8-${ARCH}.patch}"
 # We use a temporary array to store non-flag arguments to avoid clobbering 
 # the parent shell's positional parameters with 'set --'.
 clean_args=()
+forward_args=() 
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --lxd-debug)
             # shellcheck disable=SC2034
             LXD_DEBUG=true
+            forward_args+=("$1")
+            ;;
+        --skip-snap-lxd)
+            # shellcheck disable=SC2034
+            SKIP_SNAP_LXD=true
+            forward_args+=("$1")
             ;;
         --skip-lxd-img-export)
             # shellcheck disable=SC2034
             SKIP_LXD_IMG_EXPORT=true
+            forward_args+=("$1")
             ;;
         --skip-lxd-img-primer)
             # shellcheck disable=SC2034
             SKIP_LXD_IMG_PRIMER=true
+            forward_args+=("$1")
             ;;
         --skip-lxd-publish)
             # shellcheck disable=SC2034
             SKIP_LXD_PUBLISH=true
+            forward_args+=("$1")
             ;;
         --skip-lxd-snapshot)
             # shellcheck disable=SC2034
             SKIP_LXD_SNAPSHOT=true
+            forward_args+=("$1")
             ;;
         -h|--help)
             usage
@@ -73,6 +86,7 @@ while [[ $# -gt 0 ]]; do
             return 1 2>/dev/null || exit 1
             ;;
         *)
+            # These are non-flag arguments (positional)
             clean_args+=("$1")
             ;;
     esac

--- a/scripts/lxd.sh
+++ b/scripts/lxd.sh
@@ -151,7 +151,7 @@ build_image() {
   # shellcheck disable=SC1073
   # shellcheck disable=SC2154
   if ! lxc exec "${BUILD_CONTAINER}" --user 0 --group 0 -- \
-    bash -c 'exec "$@"' _ "${helper_script_folder}/setup_install.sh" "${IMAGE_OS}" "${IMAGE_VERSION}" "${WORKER_TYPE}" "${WORKER_CPU}" "${SETUP}"; then
+    bash -c 'exec "$@"' _ "${helper_script_folder}/setup_install.sh" "${clean_args[@]}" "${forward_args[@]}"; then
 
     msg "!!! The installation script inside the container failed. Triggering cleanup. !!!" >&2
     return 1 # Exit with an error code to trigger the trap and signal failure

--- a/scripts/vm.sh
+++ b/scripts/vm.sh
@@ -42,7 +42,8 @@ msg "Copy the gha-service unit file into gha-builder"
 cp -r "${BUILD_PREREQS_PATH}"/assets/gha-runner.service "/etc/systemd/system/gha-runner.service"
 chmod -R 0755 /etc/systemd/system/gha-runner.service
 
-sudo bash -c 'exec "$@"' _ "${HELPER_SCRIPTS}/setup_install.sh" "${IMAGE_OS}" "${IMAGE_VERSION}" "${WORKER_TYPE}" "${WORKER_CPU}" "${SETUP}"
+# shellcheck disable=SC2154
+sudo bash -c 'exec "$@"' _ "${HELPER_SCRIPTS}/setup_install.sh" "${clean_args[@]}" "${forward_args[@]}"
 
 sudo bash -c 'id -u runner >/dev/null 2>&1 || (useradd -c "Action Runner" -m -s /bin/bash runner && usermod -L runner && echo "runner ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/runner && chmod 440 /etc/sudoers.d/runner)'
 


### PR DESCRIPTION
#### Summary

This PR replaces the `sed` workaround in the GitHub Actions workflow with a native `--skip-snap-lxd` flag in the setup scripts. Additionally, it refactors how arguments are parsed and passed into LXD containers to ensure flags are propagated correctly.

#### Motivation

Previously, the `gaplib_complete_lxd_build.yml` workflow used `sed` to modify `setup_install.sh` in-place to remove Snap and LXD installation steps. This was brittle and difficult to maintain.

To fix this properly, I have:

1. Implemented a conditional check for Snap/LXD installation.
2. Added a flag to control this behavior.
3. Fixed `lxd.sh` to correctly forward flags (like `--skip-*`) into the build container, which was previously stripping them or failing to pass them down.

#### Changes

-  **`.github/workflows/...`** : Removed the `sed` line and updated the build command to use `--skip-snap-lxd`.
- **`scripts/helpers/setup_install.sh`**:

  - Removed `install-snap.sh`, `install-lxd.sh`, and `configure-snap.sh` from the static installation arrays.
  - Added a conditional block that runs these scripts only if `SKIP_SNAP_LXD` is not true.
- **`scripts/helpers/setup_vars.sh`**:

  - Added `SKIP_SNAP_LXD` default and flag parsing.
  - **Fix**: Introduced `forward_args` array to capture flags separately from positional arguments (`clean_args`) so they can be passed to child processes.
- **`scripts/lxd.sh`**:

  - Updated the `lxc exec` command to pass `${clean_args[@]}` and `${forward_args[@]}` instead of hardcoded variables. This ensures the new `--skip` flags reach the inner installation script.